### PR TITLE
Handle subgroups on different routes/worlds

### DIFF
--- a/bakpdlbot/zwiftcom/events.py
+++ b/bakpdlbot/zwiftcom/events.py
@@ -107,7 +107,7 @@ class Event(Eventish):
         return "https://www.zwift.com/events/view/{}".format(self.id)
 
 
-def get_event(eid: int, secret: None) -> Event:
+def get_event(eid: int, secret: str = None) -> Event:
     url = "https://us-or-rly101.zwift.com/api/public/events/{}".format(int(eid))
     if secret is not None:
         params = {'eventSecret': secret}


### PR DESCRIPTION
Will not show a combined route/map, but instead show them for each subgroup if they differ.

![image](https://user-images.githubusercontent.com/394856/154168315-ab5ba887-4c92-45db-b36f-af01de6663bc.png)
